### PR TITLE
Reuse color coded for officers

### DIFF
--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -6,4 +6,13 @@ export const DEFAULT_THEME = createTheme({
       main: '#C38900',
     },
   },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
+      },
+    },
+  },
 });

--- a/src/app/hanzhong/formations/Character.tsx
+++ b/src/app/hanzhong/formations/Character.tsx
@@ -25,14 +25,13 @@ export const HanzhongFormationsCharacter = ({ label, info, onClick }: HanzhongFo
 
   return (
     <Grid container direction="row" spacing={1} sx={{ p: 0 }}>
-      <OfficerAvatar officerId={officerId} roster={roster} onClick={() => onClick(info.officer)} />
+      <OfficerAvatar officerId={officerId} roster={roster} onClick={() => onClick(info.officer)} small />
 
-      <Box sx={{ width: '70px' }}>
+      <Box sx={{ width: '75px' }}>
         <DebouncedInputField
           label={label}
           value={getNumberValue(formationsUserData, info.tacticalPoints, 0)}
           onChange={fieldValueChanged}
-          small
         />
       </Box>
     </Grid>

--- a/src/app/hanzhong/formations/CharacterSelector.tsx
+++ b/src/app/hanzhong/formations/CharacterSelector.tsx
@@ -8,6 +8,9 @@ import Grid from '@mui/material/Grid';
 import { useTheme } from '@mui/material/styles';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 
 import { useAppContext } from '../../Context';
 import { OFFICERS } from '../../data';
@@ -16,6 +19,7 @@ import { getStringValue } from '../../utils';
 import { useHanzhongContext } from '../HanzhongContext';
 
 import { STRUCTURED_FORMATIONS_KEYS } from './structured-formations';
+import ButtonGroup from '@mui/material/ButtonGroup';
 
 export type HanzhongFormationsCharacterSelectorProps = {
   formationCharacterId: string;
@@ -74,25 +78,30 @@ export const HanzhongFormationsCharacterSelector = ({
       </DialogContent>
       <DialogActions>
         <Button onClick={() => setShowAllOfficers(!showAllOfficers)}>
-          All {showAllOfficers ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
+          {showAllOfficers ? <CheckBoxIcon sx={{ fontSize: '1em' }} /> : <CheckBoxOutlineBlankIcon sx={{ fontSize: '1em' }} />}
+          All
         </Button>
 
         {currentSelectedOfficer ? (
-          <>
-            <Button onClick={() => onSelect(currentSelectedOfficer)} color="success" variant="contained">
+          <ButtonGroup>
+            <Button onClick={() => onSelect(currentSelectedOfficer)} color="primary" variant="contained">
+              <ThumbUpIcon sx={{ fontSize: '1em' }} />
               Keep
             </Button>
             <Button onClick={() => onSelect('')} color="error" variant="outlined">
+              <DeleteIcon sx={{ fontSize: '1em' }} />
               Remove
             </Button>
-          </>
+          </ButtonGroup>
         ) : (
-          <Button onClick={() => onSelect(currentSelectedOfficer)} color="success" variant="contained">
+          <Button onClick={() => onSelect(currentSelectedOfficer)} color="primary" variant="contained">
             Cancel
           </Button>
         )}
 
-        <Button onClick={() => navigate('/officers')}>Roster</Button>
+        <Button onClick={() => navigate('/officers')}>
+          <ManageAccountsIcon sx={{ fontSize: '1em' }} /> Roster
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/app/hanzhong/formations/CharacterSelector.tsx
+++ b/src/app/hanzhong/formations/CharacterSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
@@ -6,6 +6,8 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import Grid from '@mui/material/Grid';
 import { useTheme } from '@mui/material/styles';
+import CheckBoxIcon from '@mui/icons-material/CheckBox';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 
 import { useAppContext } from '../../Context';
 import { OFFICERS } from '../../data';
@@ -29,6 +31,8 @@ export const HanzhongFormationsCharacterSelector = ({
   const { formationsUserData } = useHanzhongContext();
   const { user } = useAppContext();
 
+  const [showAllOfficers, setShowAllOfficers] = useState<boolean>(false);
+
   const roster = useMemo(() => user.officers ?? {}, [user.officers]);
 
   if (!formationCharacterId) {
@@ -50,6 +54,10 @@ export const HanzhongFormationsCharacterSelector = ({
           {OFFICERS.map((officer) => {
             const isAlreadyInFormation = otherSelectedOfficers.has(officer.id);
 
+            if (!showAllOfficers && !roster[officer.id]) {
+              return null;
+            }
+
             return (
               <OfficerAvatar
                 key={officer.id}
@@ -65,6 +73,10 @@ export const HanzhongFormationsCharacterSelector = ({
         </Grid>
       </DialogContent>
       <DialogActions>
+        <Button onClick={() => setShowAllOfficers(!showAllOfficers)}>
+          All {showAllOfficers ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
+        </Button>
+
         {currentSelectedOfficer ? (
           <>
             <Button onClick={() => onSelect(currentSelectedOfficer)} color="success" variant="contained">

--- a/src/app/officers/Card.stories.ts
+++ b/src/app/officers/Card.stories.ts
@@ -10,7 +10,7 @@ const defaultProps: OfficerCardProps = {
   selectedFaction: '',
   selectedAptitude: '',
   selectedOfficerType: '',
-  inRoster: false,
+  roster: {},
   onRosterUpdated: fn(),
 };
 

--- a/src/app/officers/Card.tsx
+++ b/src/app/officers/Card.tsx
@@ -6,9 +6,10 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
 import { getAptitudeById, getFactionById, getOfficerTypeById } from '../data';
-import { CardWrapper, WrappedIconButton } from '../shared';
+import { CardWrapper, OfficerAvatar, WrappedIconButton } from '../shared';
 import type { OfficerType, OfficerTypeType } from '../types';
 import { assetPath } from '../utils';
+import type { OfficersRosterData } from './types';
 
 export type OfficerCardProps = {
   officer: OfficerType;
@@ -16,7 +17,7 @@ export type OfficerCardProps = {
   selectedAptitude: string;
   selectedOfficerType: string;
   onRosterUpdated: (id: string) => void;
-  inRoster: boolean;
+  roster: OfficersRosterData;
 };
 
 export const OfficerCard = ({
@@ -25,7 +26,7 @@ export const OfficerCard = ({
   selectedAptitude,
   selectedOfficerType,
   onRosterUpdated,
-  inRoster,
+  roster,
 }: OfficerCardProps) => {
   const faction = getFactionById(officer.factionId);
   const aptitude = getAptitudeById(officer.aptitudeId);
@@ -38,6 +39,7 @@ export const OfficerCard = ({
     (selectedAptitude === '' || selectedAptitude === officer.aptitudeId) &&
     (selectedOfficerType === '' || officer.officerTypeIds.includes(selectedOfficerType));
 
+  const inRoster = roster[officer.id];
   const rosterOpacity = inRoster ? 1 : 0.75;
   const opacity = isVisible ? rosterOpacity : 0.2;
 
@@ -46,12 +48,10 @@ export const OfficerCard = ({
     : { label: 'Add to roster', Icon: Person4OutlinedIcon, onClick: () => onRosterUpdated(officer.id) };
 
   return (
-    <CardWrapper sx={{ backgroundColor: aptitude?.palette.background.default, opacity }}>
+    <CardWrapper sx={{ backgroundColor: faction.color, opacity }}>
       <Grid container size={12} spacing={1}>
         <Grid size="auto">
-          <Box sx={{ width: '100%', maxWidth: { xs: '30px', sm: '50px' } }}>
-            <img src={assetPath(officer.avatar.path)} alt={officer.name} width="100%" />
-          </Box>
+          <OfficerAvatar officerId={officer.id} roster={roster} />
         </Grid>
         <Grid size="grow" container direction={'row'} spacing={0}>
           <Grid size={3}>

--- a/src/app/officers/Layout.tsx
+++ b/src/app/officers/Layout.tsx
@@ -59,7 +59,7 @@ export const OfficersLayout = () => {
               selectedAptitude={selectedAptitude}
               selectedOfficerType={selectedOfficerType}
               onRosterUpdated={updateRoster}
-              inRoster={userOfficers[officer.id]}
+              roster={userOfficers}
             />
           </Grid>
         ))}

--- a/src/app/shared/OfficerAvatar.tsx
+++ b/src/app/shared/OfficerAvatar.tsx
@@ -12,7 +12,8 @@ export type OfficerAvatarProps = {
   disabled?: boolean;
   selectedOfficerId?: string;
   selectedColor?: string;
-  onClick: () => void;
+  onClick?: () => void;
+  small?: boolean;
 };
 
 export const OfficerAvatar = ({
@@ -22,36 +23,43 @@ export const OfficerAvatar = ({
   selectedOfficerId,
   selectedColor = 'transparent',
   disabled,
+  small,
 }: OfficerAvatarProps) => {
   const officer = officerId ? getOfficerById(officerId) : undefined;
   const aptitudeColor = officer ? getAptitudeById(officer.aptitudeId).palette.background.default : 'transparent';
   const factionColor = officer ? getFactionById(officer.factionId).color : 'transparent';
 
-  const inRosterOpacity = roster[officerId ?? ''] ? 1 : 0.6;
+  const inRosterOpacity = roster[officerId] ? 1 : 0.6;
+
+  const size = small ? '27px' : '32px';
+
+  const avatar = (
+    <Avatar
+      alt={officer?.name}
+      src={assetPath(officer?.avatar.path)}
+      sx={{ width: size, height: size, border: `3px solid ${aptitudeColor}` }}
+    />
+  );
+
+  const iconButton = onClick ? (
+    <IconButton sx={{ width: size }} onClick={() => onClick()} disabled={disabled}>
+      {avatar}
+    </IconButton>
+  ) : (
+    avatar
+  );
 
   return (
     <Box
-      key={officer?.id}
       sx={{
         backgroundColor: factionColor,
         opacity: disabled ? 0.2 : inRosterOpacity,
-        borderRadius: '12px',
+        borderRadius: 'calc(12px / 2)',
+        border: `2px solid ${officerId === selectedOfficerId ? selectedColor : 'transparent'}`,
+        // height: '50px',
       }}
     >
-      <IconButton
-        sx={{
-          width: '30px',
-          border: `3px solid ${officer?.id === selectedOfficerId ? selectedColor : 'transparent'}`,
-        }}
-        onClick={() => onClick()}
-        disabled={disabled}
-      >
-        <Avatar
-          alt={officer?.name}
-          src={assetPath(officer?.avatar.path)}
-          sx={{ width: '30px', height: '30px', border: `2px solid ${aptitudeColor}` }}
-        />
-      </IconButton>
+      {iconButton}
     </Box>
   );
 };


### PR DESCRIPTION
Modified the officers page to use the faction as background instead of aptitude color-code:
<img width="908" height="448" alt="image" src="https://github.com/user-attachments/assets/ae7919a0-e50e-44f5-8da6-fb76f2ff7f91" />


Added option to show all officers or only those on the roster:
<img width="858" height="538" alt="image" src="https://github.com/user-attachments/assets/77bbb5d7-f70c-4273-a9c4-04a161aed134" />
