### PR TITLE
- #71: Color-coded territories according to the lowest tactical points.

### DIFF
--- a/src/app/hanzhong/HanzhongContext.tsx
+++ b/src/app/hanzhong/HanzhongContext.tsx
@@ -22,7 +22,7 @@ export const DEFAULT_HANZHONG_CONTEXT_DATA: HanzhongContextType = {
   onChange: () => {},
   formationsUserData: {},
   onChangeFormations: () => {},
-  cache: { requirements: {} },
+  cache: { requirements: {}, tacticalPoints: [] },
 };
 
 export const HanzhongContext = createContext<HanzhongContextType>({ ...DEFAULT_HANZHONG_CONTEXT_DATA });

--- a/src/app/hanzhong/TacticalBonuses.tsx
+++ b/src/app/hanzhong/TacticalBonuses.tsx
@@ -8,7 +8,7 @@ import type { HanzhongInfoDataType } from './types';
 import { calculateSpecialTrainingsTacticalPoints } from './utils';
 
 export const TacticalBonuses = () => {
-  const { bonuses, user, formationsUserData } = useHanzhongContext();
+  const { bonuses, user, formationsUserData, cache } = useHanzhongContext();
   const navigate = useNavigate();
 
   const configure = () => navigate(HANZHONG_ROUTES.FORMATIONS);
@@ -17,6 +17,8 @@ export const TacticalBonuses = () => {
     () => calculateSpecialTrainingsTacticalPoints(user, bonuses, formationsUserData),
     [user, bonuses, formationsUserData]
   );
+
+  cache.tacticalPoints = items;
 
   return <HanzhongInfosDisplay label="Tactical Points" items={items} configure={configure} />;
 };

--- a/src/app/hanzhong/layout.tsx
+++ b/src/app/hanzhong/layout.tsx
@@ -52,7 +52,7 @@ export const HanzhongLayout = () => {
       onChange,
       formationsUserData,
       onChangeFormations,
-      cache: { requirements: {} },
+      cache: { requirements: {}, tacticalPoints: [] },
     });
   }, [userData, formationsUserData, bonuses]);
 

--- a/src/app/hanzhong/territories/TerritoryLevel.tsx
+++ b/src/app/hanzhong/territories/TerritoryLevel.tsx
@@ -2,6 +2,9 @@ import Grid from '@mui/material/Grid';
 
 import { TerritoryLevelResource } from './TerritoryLevelResource';
 import type { HanzhongTerritoryLevelType } from './TerritoryLevelType';
+import { useHanzhongContext } from '../HanzhongContext';
+
+const THRESHOLD = 0.7;
 
 export type TerritoryLevelProps = {
   index: number;
@@ -9,16 +12,26 @@ export type TerritoryLevelProps = {
 };
 
 export const TerritoryLevel = ({ index, level }: TerritoryLevelProps) => {
+  const { cache } = useHanzhongContext();
+
+  const minTacticalPoints = Math.min(...cache.tacticalPoints.map<number>((info) => info.value));
+  let color: string = 'red';
+  if (minTacticalPoints >= level.tacticalPoints) {
+    color = 'darkgreen';
+  } else if (minTacticalPoints / THRESHOLD >= level.tacticalPoints) {
+    color = 'DarkOrange';
+  }
+
   return (
     <Grid container direction={{ xs: 'row' }} spacing={1}>
       <Grid size={4}>
-        <TerritoryLevelResource label="Woodland" level={index + 1} earning={level.earnings[0]} />
+        <TerritoryLevelResource label="Woodland" level={index + 1} earning={level.earnings[0]} color={color} />
       </Grid>
       <Grid size={4}>
-        <TerritoryLevelResource label="Farmland" level={index + 1} earning={level.earnings[1]} />
+        <TerritoryLevelResource label="Farmland" level={index + 1} earning={level.earnings[1]} color={color} />
       </Grid>
       <Grid size={4}>
-        <TerritoryLevelResource label="Iron Mine" level={index + 1} earning={level.earnings[2]} />
+        <TerritoryLevelResource label="Iron Mine" level={index + 1} earning={level.earnings[2]} color={color} />
       </Grid>
     </Grid>
   );

--- a/src/app/hanzhong/territories/TerritoryLevelResource.tsx
+++ b/src/app/hanzhong/territories/TerritoryLevelResource.tsx
@@ -11,13 +11,14 @@ export type TerritoryLevelResourceProps = {
   label: string;
   level: number;
   earning: HanzhongTerritoryLevelEarningsType;
+  color: string;
 };
 
-export const TerritoryLevelResource = ({ label, level, earning }: TerritoryLevelResourceProps) => {
+export const TerritoryLevelResource = ({ label, level, earning, color }: TerritoryLevelResourceProps) => {
   const { user, onChange } = useHanzhongContext();
 
   return (
-    <CardWrapper>
+    <CardWrapper sx={{ border: `1px solid ${color}` }}>
       <Grid container sx={{ justifyContent: 'center', alignItems: 'center' }} direction="column">
         <Grid container direction="row">
           <Grid size="auto" display={{ xs: 'none', sm: 'block' }}>
@@ -25,12 +26,12 @@ export const TerritoryLevelResource = ({ label, level, earning }: TerritoryLevel
           </Grid>
           <Grid container size="grow">
             <Grid size={{ xs: 12 }}>
-              <Typography align="center" sx={{ fontSize: 12 }}>
+              <Typography align="center" sx={{ fontSize: 12, color }}>
                 Lv.{level}
               </Typography>
             </Grid>
             <Grid size={{ xs: 12 }}>
-              <Typography align="center" sx={{ fontSize: 13 }}>
+              <Typography align="center" sx={{ fontSize: 13, color }}>
                 {label}
               </Typography>
             </Grid>

--- a/src/app/hanzhong/types/ContextCache.ts
+++ b/src/app/hanzhong/types/ContextCache.ts
@@ -1,5 +1,7 @@
 import type { RequirementsCache } from '../requirements/RequirementsCache';
+import type { HanzhongInfoDataType } from './hanzhong-info-data-type';
 
 export type HanzhongContextCache = {
   requirements: RequirementsCache;
+  tacticalPoints: HanzhongInfoDataType[];
 };


### PR DESCRIPTION
Adding colors to territories in order to help identify which territory levels can be occupied.

<img width="416" height="278" alt="image" src="https://github.com/user-attachments/assets/20c05a96-5fc5-44ba-bfe5-ed69e682d3d3" />
